### PR TITLE
format money (like '$32124534' -> '$32,124,534')

### DIFF
--- a/money.html
+++ b/money.html
@@ -619,6 +619,19 @@
 
 </center>
 <script>
+	// format money like  124699926725 -> $124,699,926,725
+	function formatmoney(moneyInt, split, start) {
+		var money = String(moneyInt)
+		var offset = money.length % 3 - 1
+		var formatted = start
+		for(i in money) {
+			formatted += money[i]
+			if(i % 3 == offset) formatted += split
+		}
+		var flipped = String(Array(formatted).reverse()) // the string is built backwards
+		return flipped.substr(0, flipped.length - 1) // trailing split character
+	}
+
     var moneydynamic = 0
     document.getElementById("JeffBezosNetWorth").innerHTML = moneydynamic;
 
@@ -941,8 +954,8 @@
 
         // moneydynamic2 = cost * currentvaluecamry
         updatedmoneydynamic = moneydynamic - moneydynamic2
-        document.getElementById("JeffBezosNetWorth").innerHTML = updatedmoneydynamic
-        document.getElementById("JeffBezosNetWorth2").innerHTML = updatedmoneydynamic
+        document.getElementById("JeffBezosNetWorth").innerHTML = formatmoney(updatedmoneydynamic, ",", "")
+        document.getElementById("JeffBezosNetWorth2").innerHTML = formatmoney(updatedmoneydynamic, ",", "")
 
         if (updatedmoneydynamic >= 0) {
             console.log("GREATER")
@@ -1007,9 +1020,8 @@
 
         // moneydynamic2 = cost * currentvaluecamry
         updatedmoneydynamic = moneydynamic - moneydynamic2
-        document.getElementById("JeffBezosNetWorth").innerHTML = updatedmoneydynamic
-        document.getElementById("JeffBezosNetWorth2").innerHTML = updatedmoneydynamic
-
+        document.getElementById("JeffBezosNetWorth").innerHTML = formatmoney(updatedmoneydynamic, ",", "")
+        document.getElementById("JeffBezosNetWorth2").innerHTML = formatmoney(updatedmoneydynamic, ",", "")
         if (updatedmoneydynamic >= 0) {
             console.log("GREATER")
             document.getElementById("JeffBezosNetWorth").style.color = "limegreen"


### PR DESCRIPTION
makes big numbers easier to read by seperating thousands, millions, billions, etc.